### PR TITLE
Add 'options.uri' to support a fully formed MongoDB URI

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,10 +14,14 @@ function mongo(options) {
   var timeout = options.timeout || 30000;
   var log = options.log || false;
   var mongoUrl = '';
-  if (options.user && options.pass) {
-    mongoUrl = 'mongodb://' + options.user + ':' + options.pass + '@' + host + ':' + port;
+  if(options.uri) {
+    mongoUrl = options.uri;
   } else {
-    mongoUrl = 'mongodb://' + host + ':' + port;
+    if (options.user && options.pass) {
+      mongoUrl = 'mongodb://' + options.user + ':' + options.pass + '@' + host + ':' + port;
+    } else {
+      mongoUrl = 'mongodb://' + host + ':' + port;
+    }
   }
   return function* (next) {
     if (!this.app._mongoPool) {


### PR DESCRIPTION
There are certain situations where the ability to supply a fully formed MongoDB URI would be beneficial. One such is for using MongoLab with a Heroku instance. Heroku adds a MONGOLAB_URI environment variable directly into the path for use. Being able to just supply a uri within the options for the module would make the coding for multiple environments much easier.
