### PR TITLE
limit mongodb version to 2.1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "debug": "2.6.0",
     "generic-pool": "3.1.6",
     "lodash": "4.17.4",
-    "mongodb": "2.2.22"
+    "mongodb": "~2.1.0"
   },
   "devDependencies": {
     "koa": "2"


### PR DESCRIPTION
`poolSize`和`uri_decode_auth`的参数传递方式在[node-mongodb-native 2.2 版本](http://mongodb.github.io/node-mongodb-native/2.2/api/MongoClient.html)做了更新，导致控制台会输出以下警告。

```
the server/replset/mongos options are deprecated, all their options are supported at the top level of the options object [poolSize,ssl,sslValidate,sslCA,sslCert,sslKey,sslPass,sslCRL,autoReconnect,noDelay,keepAlive,connectTimeoutMS,family,socketTimeoutMS,reconnectTries,reconnectInterval,ha,haInterval,replicaSet,secondaryAcceptableLatencyMS,acceptableLatencyMS,connectWithNoPrimary,authSource,w,wtimeout,j,forceServerObjectId,serializeFunctions,ignoreUndefined,raw,promoteLongs,bufferMaxEntries,readPreference,pkFactory,promiseLibrary,readConcern,maxStalenessSeconds,loggerLevel,logger,promoteValues,promoteBuffers,promoteLongs,domainsEnabled,keepAliveInitialDelay,checkServerIdentity,validateOptions,appname]
the options [uri_decode_auth] is not supported
```

将`mongodb`的版本锁定在`2.1.x`可以避免此类问题的产生。
