### PR TITLE
create a new pool when mongo server instance pool is destroyed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-mongo",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "MongoDB middleware for koa, support connection pool.",
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "debug": "2.6.0",
     "generic-pool": "2.5.4",
-    "mongodb": "~2.1.0"
+    "mongodb": "~2.1.0",
+    "promise-retry": "1.0.0"
   },
   "devDependencies": {
     "koa": "1.2.4"


### PR DESCRIPTION
When mongo is down and the MongoClient has gone through the reconnectTries, the mongo server instance pool gets destroyed. This means that the server using the koa-mongo middleware will have to get restarted in order for koa-mongo to create a new connection pool. 
With this change, the acquired connection object is first checked if it is connected with the mongo server. If it is not, the middleware waits for the reconnect tries interval before creating a new pool and acquiring a new connection object.