### PR TITLE
Fix for generic pool swallowing mongo client connection errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,10 +31,15 @@ function mongo (options) {
   }
 
   const mongoPool = genericPool.createPool({
-    create: () => MongoClient.connect(mongoUrl, {
-      useNewUrlParser: true,
-      reconnectTries: 1
-    }),
+    create: () => MongoClient.connect(mongoUrl, { useNewUrlParser: true, reconnectTries: 1 })
+      .catch(err => {
+        debug('Failed to connect to database');
+        return new Error(err);
+      })
+      .then(client => {
+        debug('Successfully connected to database');
+        return client;
+      }),
     destroy: client => client.close()
   }, options)
 


### PR DESCRIPTION
Hey, thought I'd do my part and contribute in what I found.

While using this library I noticed that on creation of mongo connections, if they error'd they would have their errors swallowed and you wouldn't be aware to this happening (e.g. auth failed and failed to connect etc).

I saw that #33 tried to do something similar but as @nswbmw said, you can't throw an error from the callback ... but this is because generic pool swallows it.

In [generic-pool](https://github.com/coopernurse/node-pool), when the `create` method is called a `factory` object is passed - if that factory returns an `Error` then the pool will throw the error for us and thus stop our koa server and make us aware somethings gone wrong.

Hope this makes sense, thanks for the middleware. 👍