### PR TITLE
Add authSource to url and options

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const defaultOptions = {
   host: 'localhost',
   port: 27017,
   db: 'test',
+  authSource = 'admin',
   max: 100,
   min: 1,
   acquireTimeoutMillis: 100
@@ -21,7 +22,7 @@ function mongo (options) {
   let dbName = options.db
   if (!mongoUrl) {
     if (options.user && options.pass) {
-      mongoUrl = `mongodb://${options.user}:${options.pass}@${options.host}:${options.port}/${options.db}`
+      mongoUrl = `mongodb://${options.user}:${options.pass}@${options.host}:${options.port}/${options.db}?authSource=${authSource}`
     } else {
       mongoUrl = `mongodb://${options.host}:${options.port}/${options.db}`
     }

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,7 @@ app.use(mongo({
   user: 'admin',
   pass: '123456',
   db: 'test',
+  authSource: 'admin',
   max: 100,
   min: 1,
   ...
@@ -27,7 +28,7 @@ or
 
 ```js
 app.use(mongo({
-  uri: 'mongodb://admin:123456@localhost:27017/test', //or url
+  uri: 'mongodb://admin:123456@localhost:27017/test?authSource=admin', //or url
   max: 100,
   min: 1
   ...
@@ -41,6 +42,7 @@ defaultOptions:
   host: 'localhost',
   port: 27017,
   db: 'test',
+  authSource: 'admin',
   max: 100,
   min: 1,
   acquireTimeoutMillis: 100


### PR DESCRIPTION
Hey, another contribution in parallel to #36.

I split these apart because I'm unsure if you will want both, or one, or the other - so tried to make this easier.

If you [enable auth](https://docs.mongodb.com/manual/tutorial/enable-authentication/) on your mongo server (and you should have if you're going anywhere near production of course...) then you'll put your user in the `admin` database.

When we connect and pass the `db: 'test'` option, mongo attempts to use that `test` db as the auth database however this isn't correct cause we of course put our user in the `admin` database, not `test`.

The solution is to simply provide authSource in the connection url - if this doesn't apply then authSource could simply be set to (or maybe even default to) the same as the `db` option.

Thanks again, hope this is useful - feel free to discuss of course 😄