### PR TITLE
Add optional configuration for MongoClient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-mongo",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "description": "MongoDB middleware for koa, support connection pool.",
   "main": "index.js",
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,21 @@ app.use(mongo({
 }));
 ```
 
+or
+
+```js
+app.use(mongo({
+  uri: 'mongodb://admin:123456@localhost:27017/test?authSource=admin', //or url
+  max: 100,
+  min: 1
+  ...
+}, {
+  useUnifiedTopology: true
+  ...
+}
+));
+```
+
 defaultOptions:
 
 ```js


### PR DESCRIPTION
I needed to configure MongoClient with `{ useUnifiedTopology: true }`, so my proposal is to add an optional object to the `mongo()` constructor.